### PR TITLE
get delay time, added error message, and bug fix

### DIFF
--- a/src/apngasm-cli.cpp
+++ b/src/apngasm-cli.cpp
@@ -5,8 +5,11 @@
 using namespace std;
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
+//#include <boost/algorithm/string/regex.hpp>
 
 #define MILISECOND 1000
+#define DERAYNUMERATOR 100
 
 bool isNumber(const string s)
 {
@@ -15,25 +18,43 @@ bool isNumber(const string s)
 	return !s.empty() && it == s.end();
 }
 
-bool parseDelay(const string delay, int *numerator, int *denominator)
+// bool parseDelay(const string delay, int *numerator, int *denominator)
+// {
+// 	if (isNumber(delay)) { // The delay is in miliseconds
+// 		*numerator = atoi(delay.c_str());
+// 		*denominator = MILISECOND;
+// 		return true;
+// 	} else { // Delay is in fractions of a second or invalid
+// 		//TODO parse numerator and denominator
+// 		vector<string> portions;
+// 		boost::algorithm::split(portions, delay, boost::is_any_of(":"));
+// 		*numerator = atoi((portions.front()).c_str()) * 1000;
+
+// 		for (vector<string>::iterator it = portions.erase(portions.begin()); it != portions.end(); ++it) {
+// 			*numerator /= (float)atoi(it->c_str());
+// 		}
+// 		*denominator = MILISECOND;
+// 	}
+// 	return false;
+// }
+
+int parseDelay(const string delay, int *denominator)
 {
+	int delays = -1;
 	if (isNumber(delay)) { // The delay is in miliseconds
-		*numerator = atoi(delay.c_str());
+		delays = atoi(delay.c_str());
 		*denominator = MILISECOND;
-		return true;
 	} else { // Delay is in fractions of a second or invalid
-		//TODO parse numerator and denominator
 		vector<string> portions;
 		boost::algorithm::split(portions, delay, boost::is_any_of(":"));
-		*numerator = atoi((portions.front()).c_str()) * 1000;
+		delays = atoi((portions.front()).c_str()) * 1000;
 
 		for (vector<string>::iterator it = portions.erase(portions.begin()); it != portions.end(); ++it) {
-			*numerator /= (float)atoi(it->c_str());
+			delays /= (float)atoi(it->c_str());
 		}
 		*denominator = MILISECOND;
-		return true;
 	}
-	return false;
+	return delays;
 }
 
 int main(int argc, char* argv[])
@@ -42,9 +63,7 @@ int main(int argc, char* argv[])
 	namespace bpo = boost::program_options;
 
 	// Defaults
-	int delayNumerator = 100;
 	int delayDenominator = MILISECOND;
-
 
 	stringstream description;
 	description << "APNG Assembler v" << apngasm.version() << endl \
@@ -95,19 +114,43 @@ int main(int argc, char* argv[])
 		cout << apngasm.version() << endl;
 	} else {
 		if (vm.count("delay")) {
-			const string delayOverride = vm["delay"].as<string>();
-			if (parseDelay(delayOverride, &delayNumerator, &delayDenominator)) {
-				cout << "Default delay overridden to: " << delayNumerator << "/" << delayDenominator << " seconds" << endl;
-			}
+			// const string delayOverride = vm["delay"].as<string>();
+			// if (parseDelay(delayOverride, &delayNumerator, &delayDenominator)) {
+			// 	cout << "Default delay overridden to: " << delayNumerator << "/" << delayDenominator << " seconds" << endl;
+			// }
 		}
 		if (vm.count("files")) {
 			vector<string> files;
+			vector<int> delay;
+			const boost::regex period(".*\\..*");
+			const boost::regex png(".*\\.png\\z");
+			const boost::regex delayNum("[0-9]+[:[0-9]+]*");
+
 			vector<string> fileParamsRaw( vm["files"].as< vector<string> >() );
 			string outputFile = fileParamsRaw.front();
+			vector<string>::iterator fileit = fileParamsRaw.erase(fileParamsRaw.begin());
+
+			if (!regex_match(*fileit, period)) {
+				cout << "there is not firstframe file" << endl;
+				return 0;
+			}
 
 			//extract individual file names
-			for (vector<string>::iterator it = fileParamsRaw.erase(fileParamsRaw.begin()); it != fileParamsRaw.end(); ++it) {
-				files.push_back(*it);
+			for (; fileit != fileParamsRaw.end(); ++fileit) {
+				if (regex_match(*fileit, period)) {
+					if (!regex_match(*fileit, png)) {
+						cout << "ERROR:  \"" << *fileit << "\" is invalid extension" << endl;
+						return 0;
+					}
+					files.push_back(*fileit);
+					delay.push_back(DERAYNUMERATOR);
+				} else {
+					if (!regex_match(*fileit, delayNum)) {
+						cout << "ERROR:  \"" << *fileit << "\" is invalid" << endl;
+						return 0;
+					}
+					*((delay.end()) - 1) = parseDelay(*fileit, &delayDenominator);
+				}
 			}
 			cout << "frame count" << files.size() << endl;
 		}


### PR DESCRIPTION
夜分遅くにすいません。
delayを実装したので、仕様通りの動きになっているかご確認ください。
string outputFileに出力ファイルパス、vector<string>filesに各フレームファイルの名前、vector<int>delayに各フレームファイルに対応したディレイ時間が格納されています。
質問なのですが、-dを書く場合と書かない場合で処理が変わらないようにしたほうがよろしいのでしょうか？
素人意見で恐縮なのですが、私はオプションではなく基本仕様にして、-dコマンドを削除したほうがプログラム的にはややこしくなくて済むのでいいと思います。
他に、勝手に関数の仕様を変更したのですが、削除していいか分からず変更前のものをコメントアウトして保存してありますので、変更前のものを使用した方がいいのかどうか教えてくれると助かります。
あと、勝手ながらエラーメッセージを追加致しましたので、不要でしたら削除致します。
長文失礼致しました。
