### PR TITLE
apngframe: Add missing include

### DIFF
--- a/lib/src/apngframe.cpp
+++ b/lib/src/apngframe.cpp
@@ -1,6 +1,7 @@
 #include "apngframe.h"
 #include <png.h>
 #include <cstdlib>
+#include <cstring>
 #include <algorithm>
 
 namespace apngasm {


### PR DESCRIPTION
This uses memset / memcpy but forgets to include the correct header
