### PR TITLE
Adding build-essential to required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Building on (Ubuntu/Debian) Linux:
 ----------------------------------
 1. Install dependencies/build chain  
     ```
-    sudo apt-get install cmake libpng-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev   libboost-filesystem-dev
+    sudo apt-get install cmake libpng-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-filesystem-dev build-essential
     ```
 2. Generate Makefiles with CMake  
     ```


### PR DESCRIPTION
Fixes the following error while trying to install it in Linux Mint:

```
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:3 (PROJECT):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/home/tuba/Documents/apngasm/build/CMakeFiles/CMakeOutput.log".
See also "/home/tuba/Documents/apngasm/build/CMakeFiles/CMakeError.log".

```