### PR TITLE
Fix static target output name conflicting with import library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,9 +64,9 @@ add_library(${APNGASM_STATIC_LIB_TARGET}
 set_target_properties(${APNGASM_STATIC_LIB_TARGET}
   PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE
-  OUTPUT_NAME apngasm-static
   CXX_STANDARD 20
 )
+target_compile_definitions(${APNGASM_STATIC_LIB_TARGET} PUBLIC APNGASM_DECLSPEC=)
 
 # Add libraries/includes
 #target_link_libraries(${APNGASM_DYNAMIC_LIB_TARGET} stdc++fs)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,6 +54,7 @@ set_target_properties(${APNGASM_DYNAMIC_LIB_TARGET}
   OUTPUT_NAME apngasm
   CXX_STANDARD 20
 )
+target_compile_definitions(${APNGASM_DYNAMIC_LIB_TARGET} PRIVATE apngasm_EXPORTS)
 
 # Add the static library/archive
 set(APNGASM_STATIC_LIB_TARGET apngasm-static)
@@ -63,7 +64,7 @@ add_library(${APNGASM_STATIC_LIB_TARGET}
 set_target_properties(${APNGASM_STATIC_LIB_TARGET}
   PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE
-  OUTPUT_NAME apngasm
+  OUTPUT_NAME apngasm-static
   CXX_STANDARD 20
 )
 


### PR DESCRIPTION
The static target output name needs to be renamed, because windows also outputs a static import library with the same extension resulting in a conflict between two files named `apngasm.lib`.

Also ensures the dynamic library is built with apngasm_EXPORTS to ensure the DLL exports the needed symbols.

This allows you to build apngasm on Windows using cmake and installing the dependencies using vcpkg.